### PR TITLE
fixed modulus size

### DIFF
--- a/src/algorithms_generate_keys.c
+++ b/src/algorithms_generate_keys.c
@@ -21,7 +21,7 @@ void generate_safe_prime(mpz_t out, int bit_len, random_fn random) {
      * expected safe prime. The reason is that we try for
      * 2 * random_prime + 1 to be prime too. If that's prime,
      * the resulting safe prime may have 2 more bits. */
-    int random_prime_bit_len = bit_len - 2;
+    int random_prime_bit_len = bit_len;
     do {
 	random_prime(p, random_prime_bit_len, random);
 	mpz_sub_ui(t1, p, 1);
@@ -57,13 +57,14 @@ key_share_t **tc_generate_keys(key_metainfo_t **out, size_t bit_size, uint16_t k
 
     static const int F4 = 65537; // Fermat fourth number.
 
-    size_t prime_size = bit_size / 2;
+    size_t p_prime_size = (bit_size + 1) / 2;
+    size_t q_prime_size = bit_size - p_prime_size;
 
     mpz_t pr, qr, p, q, d, e, ll, m, n, delta_inv, divisor, r, vk_v, vk_u, s_i, vk_i;
     mpz_inits(pr, qr, p, q, d, e, ll, m, n, delta_inv, divisor, r, vk_v, vk_u, s_i, vk_i, NULL);
 
-    generate_safe_prime(p, prime_size, random_dev);
-    generate_safe_prime(q, prime_size, random_dev);
+    generate_safe_prime(p, p_prime_size, random_dev);
+    generate_safe_prime(q, q_prime_size, random_dev);
 
     // p' = (p-1)/2
     mpz_sub_ui(pr, p, 1);
@@ -76,6 +77,7 @@ key_share_t **tc_generate_keys(key_metainfo_t **out, size_t bit_size, uint16_t k
     // n = p * q, m = p' * q'
     mpz_mul(n, p, q);
     mpz_mul(m, pr, qr);
+    
     TC_MPZ_TO_BYTES(info->public_key->n, n);
 
     mpz_set_ui(ll, l);

--- a/src/algorithms_generate_keys.c
+++ b/src/algorithms_generate_keys.c
@@ -17,10 +17,6 @@ void generate_safe_prime(mpz_t out, int bit_len, random_fn random) {
     mpz_inits(p, q, r, t1, NULL);
     int q_composite, r_composite;
 
-    /* The random prime has to be at most 2 bits less than the
-     * expected safe prime. The reason is that we try for
-     * 2 * random_prime + 1 to be prime too. If that's prime,
-     * the resulting safe prime may have 2 more bits. */
     int random_prime_bit_len = bit_len;
     do {
 	random_prime(p, random_prime_bit_len, random);

--- a/tests/test_base64.c
+++ b/tests/test_base64.c
@@ -56,7 +56,7 @@ START_TEST(encode_decode)
         char *b64 = tc_bytes_b64(&bs);
 
         bytes_t *new_bs = tc_b64_bytes(b64);
-        memcmp(b, new_bs->data, 10);
+        ck_assert_msg(memcmp(b, new_bs->data, 10) == 0, "encoded-decoded message is different from original\n");
 
         free(b64);
         tc_clear_bytes(new_bs);

--- a/tests/test_structs_serialization.c
+++ b/tests/test_structs_serialization.c
@@ -75,7 +75,7 @@ END_TEST
 START_TEST(test_serialization_key_metainfo)
     {
         key_metainfo_t *mi;
-        key_share_t **shares = tc_generate_keys(&mi, 512, 3, 5, NULL);
+        key_share_t **shares = tc_generate_keys(&mi, 1024, 3, 5, NULL);
 
         char *mi_b64 = tc_serialize_key_metainfo(mi);
         key_metainfo_t *new_mi = tc_deserialize_key_metainfo(mi_b64);
@@ -101,6 +101,7 @@ END_TEST
 
 TCase *tc_test_case_serialization() {
     TCase *tc = tcase_create("poly.c");
+    tcase_set_timeout(tc, 10);
     tcase_add_test(tc, test_serialization_key_share);
     tcase_add_test(tc, test_serialization_key_share_error);
     tcase_add_test(tc, test_serialization_signature_share);

--- a/tests/test_structs_serialization.c
+++ b/tests/test_structs_serialization.c
@@ -75,7 +75,7 @@ END_TEST
 START_TEST(test_serialization_key_metainfo)
     {
         key_metainfo_t *mi;
-        key_share_t **shares = tc_generate_keys(&mi, 1024, 3, 5, NULL);
+        key_share_t **shares = tc_generate_keys(&mi, 512, 3, 5, NULL);
 
         char *mi_b64 = tc_serialize_key_metainfo(mi);
         key_metainfo_t *new_mi = tc_deserialize_key_metainfo(mi_b64);


### PR DESCRIPTION
changed the sizes of the generated primes so that the size of the modulus is actually 1024 bits (previously, the generated modulus had 1006-1010 bits)